### PR TITLE
Trying to reduplicate failing action

### DIFF
--- a/.github/scripts/verifyPodfile.sh
+++ b/.github/scripts/verifyPodfile.sh
@@ -4,8 +4,9 @@
 # First argument (required): the branch to compare against for removals
 # Second argument (optional): `-v` which will output each branches podspecs and the removals if they exist
 
-declare -r GREEN='\033[0;32m'
 declare -r RED='\033[0;31m'
+declare -r YELLOW='\033[0;33m'
+declare -r GREEN='\033[0;32m'
 declare -r NC='\033[0m'
 
 podfileSha=$(openssl sha1 ios/Podfile | awk '{print $2}')
@@ -36,6 +37,8 @@ if [ -z "$(git diff --name-only .."$1" package-lock.json package.json)" ]; then
   echo -e "${GREEN}No changes to npm packages were detected.${NC}"
   exit 0;
 fi
+
+echo -e "${YELLOW}Verifying that pods are synced...${NC}"
 
 # Extracts an array of podspec paths from the config command
 _grab_specs() {
@@ -84,7 +87,7 @@ npm i --loglevel silent
 # Initialize failed variable as it may be already set by the environment
 failed=0
 
-echo "Comparing.  This may take a moment..."
+echo -e "${YELLOW}Comparing pods.  This may take a moment.${NC}"
 
 # Validate additions and updates to Podfile.lock
 while read -r SPEC; do

--- a/.github/scripts/verifyPodfile.sh
+++ b/.github/scripts/verifyPodfile.sh
@@ -74,7 +74,7 @@ removed_specs=$(jq -n --jsonargs '$ARGS.positional | first - last | .' -- "$main
 formatted_removals="$(_formatted_pod_list "$removed_specs")"
 
 # Verbose output
-([ "$2" == "-v" ]) && \
+[ "$2" == "-v" ] && \
 ([ -n "$formatted_removals" ] && \
 echo -e "Removals:\n$formatted_removals" || \
 echo "No package removals")

--- a/.github/scripts/verifyPodfile.sh
+++ b/.github/scripts/verifyPodfile.sh
@@ -2,7 +2,7 @@
 
 # This script accepts two arguments:
 # First argument (required): the branch to compare against for removals
-# Second argument (optional): `-v` which will output each branches podspecs and the removals if they exist
+# Second argument (optional): `-v` which will output each branch's podspecs and the removals if they exist
 
 declare -r RED='\033[0;31m'
 declare -r YELLOW='\033[0;33m'

--- a/.github/scripts/verifyPodfile.sh
+++ b/.github/scripts/verifyPodfile.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# First argument is the branch to compare against for deletions
+# Second argument is optionally `-v` which will output the branch podspecs and the subtractions if they exist
+
 declare -r GREEN='\033[0;32m'
 declare -r RED='\033[0;31m'
 declare -r NC='\033[0m'
@@ -11,9 +14,74 @@ echo "Podfile: $podfileSha"
 echo "Podfile.lock: $podfileLockSha"
 
 if [ "$podfileSha" == "$podfileLockSha" ]; then
-    echo -e "${GREEN}Podfile verified!${NC}"
-    exit 0
+    echo -e "${GREEN}Podfile checksum verified!${NC}"
 else
-    echo -e "${RED}Error: Podfile.lock out of date with Podfile. Did you forget to run \`npx pod-install\`?${NC}"
+    echo -e "${RED}Error: Podfile.lock checksum mismatch. Did you forget to run \`npx pod-install\`?${NC}"
     exit 1
 fi
+
+# Maps a list of podspec paths to formatted `Pod (version)` format
+_formatted_pods() {
+    jq --raw-output --slurp 'map((.name + " (" + .version + ")")) | .[]' <<< "$( \
+      echo "$1" | \
+      xargs -L 1 pod ipc spec --silent
+    )"
+}
+
+# Checks whether a formatted version of the Pod (version) exists in the Podfile.lock
+_in_podlock() {
+  grep -q "$1" ./ios/Podfile.lock
+}
+
+# Extracts a list of podspec paths from react-native command
+_get_specs() {
+  npx react-native config | jq '.dependencies[].platforms.ios.podspecPath | select( . != null )'
+}
+
+# Store the feature branch's podspecs in a variable so we can compare against main branch (for determining removals)
+feature_branch_specs="$(_get_specs)"
+
+## Verbosity
+[ "$2" == "-v" ] && echo "Feature branch specs:" && echo "$feature_branch_specs"
+
+# Grab the podspecs from the main branch by checking out npm package and lockfile
+git checkout --quiet "$1" -- {package,package-lock}.json
+npm i --silent
+main_branch_specs="$(_get_specs)"
+
+# Verbosity
+[ "$2" == "-v" ] && echo "Main branch specs:" && echo "$main_branch_specs"
+
+# Perform an array subtraction to determine which pods were removed
+# Store the formatted version here as we won't have the chance after switching back to feature branch
+formatted_subtractions="$(_formatted_pods "$(jq -n --args '$ARGS.positional | map(. / "\n" | map(fromjson)) | first - last | .[]' -- \
+"$main_branch_specs" "$feature_branch_specs")")"
+
+# Verbosity
+[ "$2" == "-v" ] && echo "Subtractions:" && echo "$formatted_subtractions"
+
+# Switch back to feature branch
+git reset --quiet HEAD {package,package-lock}.json
+git checkout --quiet -- {package,package-lock}.json
+npm i --silent
+
+# Validate additions and updates to Podfile.lock (check whether feature branch specs _are not_ in Podfile.lock)
+while read -r SPEC; do
+  if ! _in_podlock "$SPEC"; then
+    echo -e "${RED}ERROR: Podspec $SPEC not found in Podfile.lock. Did you forget to run \`pod install\`?"
+    failed=1
+  fi
+done <<< "$(_formatted_pods "$feature_branch_specs")"
+
+# Validate deletions (check whether the subtractions _are_ in Podfile.lock)
+while read -r SPEC; do
+  if [ ! -z "$SPEC" ] && _in_podlock "$SPEC"; then
+    echo -e "${RED} ERROR: Podspec $SPEC was found in Podfile.lock and not part of project. Did you forget to run \`pod install\` after removing the package?"
+    failed=1
+  fi
+done <<< "$formatted_subtractions"
+
+[ "$failed" != "" ] && exit 1
+
+echo -e "${GREEN}Podfile.lock is synced with podspecs."
+exit 0

--- a/.github/scripts/verifyPodfile.sh
+++ b/.github/scripts/verifyPodfile.sh
@@ -58,7 +58,7 @@ feature_branch_specs="$(_grab_specs)"
 
 # Grab the podspecs from the main branch by checking out the diffed npm packages
 git checkout --quiet "$1" -- {package,package-lock}.json
-npm i --silent
+npm i --loglevel silent
 main_branch_specs="$(_grab_specs)"
 
 # Verbose output
@@ -79,10 +79,12 @@ echo "No package removals")
 # Revert back to feature branch npm state
 git reset --quiet HEAD {package,package-lock}.json
 git checkout --quiet -- {package,package-lock}.json
-npm i --silent
+npm i --loglevel silent
 
 # Initialize failed variable as it may be already set by the environment
 failed=0
+
+echo "Comparing.  This may take a moment..."
 
 # Validate additions and updates to Podfile.lock
 while read -r SPEC; do

--- a/.github/workflows/verifyPodfile.yml
+++ b/.github/workflows/verifyPodfile.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   verify:
     if: github.actor != 'OSBotify'
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     steps:
       # This action checks-out the repository, so the workflow can access it.
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -17,4 +17,4 @@ jobs:
 
       - uses: Expensify/App/.github/actions/composite/setupNode@main
 
-      - run: ./.github/scripts/verifyPodfile.sh
+      - run: ./.github/scripts/verifyPodfile.sh origin/main

--- a/.github/workflows/verifyPodfile.yml
+++ b/.github/workflows/verifyPodfile.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   verify:
     if: github.actor != 'OSBotify'
-    runs-on: macOS-latest
+    runs-on: macos-latest
     steps:
       # This action checks-out the repository, so the workflow can access it.
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
### Details

This PR updates the verifyPodfile.sh workflow script to catch uncommitted Podfile.lock changes.

In addition to all of the changes we've discussed in the [issue](https://github.com/Expensify/App/issues/13397), it:

- Modifies verifyPodfile.sh further to account for package removals.  This adds some complexity so I broke the logic Rory wrote out into functions so it could be re-used for the removal logic.  The removal logic mostly works as described in this [comment](https://github.com/Expensify/App/issues/13397#issuecomment-1356921279).  
- To elaborate on one of the differences, in my finalized script I switch to main branch and grab the main branch podspecs at the beginning so we don't have to swap package-lock.json more than once in the script.  This is done because the subtractions (`main_branch_podspecs - feature_branch_podspecs`) are ultimately evaluated against the feature branch's Podfile.lock at the end of the script.
- Two flags have been added to the `verifyPodfile.sh` script. The first flag specifies the branch to compare against for removals.  It should be `origin/main` in the production version. Since the GitHub checkout action only fetches the remote refs, it checks out the package-lock.json from origin/main.  This flag eases testing of the script on development environments where you would likely be comparing against `main`.
- The second flag is just `-v` for verbosity.  It simply outputs the podspecs from the main branch, feature branch, and finally the subtracted packages between both to ease debugging.  I have removed that argument in this PR as it was mostly for solving issues during testing.
- This PR modifies the messages outputted by the original verifyPodfile.sh logic to clarify that the original portion of the script only compares the checksums to help avoid confusion.
- I completed a sequence of tests on an example branch in my fork to demonstrate that it works for all cases in an actual runner.  See [here](https://github.com/redstar504/ExpensifyApp/pull/5).  My tests specified the verbose flag so you would see outputs of that in the runner logs.  They were also performed before the change described in the previous point.
- A good chunk of the script is just for debugging purposes and for easing testing.  The logic for the validating itself is fairly straight forward, it just requires the specific state that the runner would be in.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

$ https://github.com/Expensify/App/issues/13397

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/13397
PROPOSAL: https://github.com/Expensify/App/issues/13397#issuecomment-1346145925

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1.  Clone the repository on a MacOS machine and complete standard project setup procedures, or, sync your node modules with the main branch (ie. `git checkout main && npm i`)
2.  Switch to a new feature branch.
3.  Add/update/remove node packages that contain autolinked pods (see some example packages below).
4. Omit running `pod install` and commit the updated `package.json` and `package-lock.json` files.
5.  Run the script from %project_root%:  `./.github/scripts/verifyPodfile.sh main`
6.  Verify the command's output shows errors corresponding to the changes that weren't committed to the Podfile.lock.
7.  Switch to `ios` directory and run `pod install`.
8. Switch back to %project_root%.
9.  Run the same command again, and verify that the command succeeds with the `Podfile.lock is synced with podspecs.` message.

**Example packages:**
`react-native-image-picker`
`react-native-image-pan-zoom`
`react-native-render-html`

I have also completed a sequence of tests in a Github runner in an example PR on my fork.  Each commit to this branch corresponds to a stage of the Podfile.lock validation that passes or fails.  See [here](https://github.com/redstar504/ExpensifyApp/pull/5).

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Not relevant to the proposed changes.

### QA Steps

1. Add/update/remove npm packages that are autolinked to Pods (see example packages below).
2. Omit running `pod install` after completing these commands.
3. Commit and push the changed `package.json` and `package-json.lock` to the staging branch.
4. Observe the Github verifyPodfile workflow. It should fail with an error message.
5. Change directory to `ios` on your machine and run `pod install`.
6. Commit the updated Podfile.lock and push the commit to the staging branch.
7. Confirm that the verifyPodfile workflow completes successfully.

**Example packages:**
`react-native-image-picker`
`react-native-image-pan-zoom`
`react-native-render-html`

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

Not relevant to proposed changes.
